### PR TITLE
fix: introduce release artifact on releases

### DIFF
--- a/.changeset/empty-wolves-push.md
+++ b/.changeset/empty-wolves-push.md
@@ -1,0 +1,5 @@
+---
+'fastly-integration': patch
+---
+
+Introduce release artifact on GitHub releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       language: node
       language-version: 24
       prepare-command: pnpm build
+      github-release-files: 'dist/fingerprint-pro-fastly-vcl-integration.vcl'
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       RUNNER_APP_PRIVATE_KEY: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by specifying which file should be included in the GitHub release.

- Release workflow update:
  * The `github-release-files` parameter was added to the `.github/workflows/release.yml` file to ensure that `dist/fingerprint-pro-fastly-vcl-integration.vcl` is included in the GitHub release artifacts.