### PR TITLE
chore: exit prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "fastly-integration": "1.0.0"


### PR DESCRIPTION
This pull request makes a single configuration change, updating the release mode in the `.changeset/pre.json` file from "pre" to "exit". This likely signals the end of a prerelease phase and prepares the project for the next release cycle.